### PR TITLE
Support parallel testing

### DIFF
--- a/example/.env
+++ b/example/.env
@@ -1,1 +1,2 @@
+RUBYOPT=-W:no-deprecated -W:no-experimental
 CYPRESS_RAILS_PORT=3009

--- a/example/db/schema.rb
+++ b/example/db/schema.rb
@@ -1,0 +1,15 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+end

--- a/example/script/test
+++ b/example/script/test
@@ -2,7 +2,13 @@
 
 set -e
 
-echo "--> Running tests in development, starting all static servers and proxying requests"
+echo "--> Setting up test database"
+rake db:test:prepare
+
+echo "--> Running system tests in development"
+rake test:system
+
+echo "--> Running Cypress tests in development, starting all static servers and proxying requests"
 rake cypress:run
 
 echo "--> Precompiling all static site assets with rake assets:precompile"

--- a/example/test/system/basics_test.rb
+++ b/example/test/system/basics_test.rb
@@ -1,0 +1,13 @@
+require "application_system_test_case"
+
+class BasicsTest < ApplicationSystemTestCase
+  parallelize(workers: 8)
+
+  24.times do |i|
+    define_method "test_route_that_uses_csrf_protection_#{i}" do
+      visit "http://blog.localhost/docs"
+
+      assert_text "API liked our CSRF token and sent back ID: 22"
+    end
+  end
+end

--- a/lib/generators/templates/static.rb
+++ b/lib/generators/templates/static.rb
@@ -1,18 +1,32 @@
 StaticRails.config do |config|
-  # Control whether static-rails adds a middleware to proxy requests to your static site servers
+  # Control whether static-rails adds a middleware to proxy requests to your
+  # static site servers
+  #
   # config.proxy_requests = !Rails.env.production?
 
-  # Control whether static-rails adds a middleware to serve your sites' compiled static assets with Static::Rack (has no effect if proxy_requests is enabled)
+  # Control whether static-rails adds a middleware to serve your sites'
+  # compiled static assets with Static::Rack (has no effect if proxy_requests
+  # is enabled)
+  #
   # config.serve_compiled_assets = Rails.env.production?
 
   # Timeout in seconds to wait when proxying to  a static server
   #   (Applies when a site has both start_server and ping_server set to true)
+  #
   # config.ping_server_timeout = 5
 
   # When true, both the proxy & static asset middleware will set a cookie
   #   named "_csrf_token" to the Rails CSRF token, allowing any client-side
   #   API requests to take advantage of Rails' request forgery protection
+  #
   # config.set_csrf_token_cookie = false
+
+  # When true, static-rails won't attempt to start a site server if another
+  # process is already bound to and is accepting TCP connections at a site's
+  # port. This is in order to play nicely with Rails parallel testing, which
+  # by default will fork multiple Rails processes for each test run
+  #
+  # config.dont_start_server_if_port_already_bound = Rails.env.test?
 
   # The list of static sites you are hosting with static-rails.
   # Note that order matters! Request will be forwarded to the first site that

--- a/lib/static-rails/configuration.rb
+++ b/lib/static-rails/configuration.rb
@@ -25,12 +25,16 @@ module StaticRails
     # When true, a cookie named "_csrf_token" will be set by static-rails middleware
     attr_accessor :set_csrf_token_cookie
 
+    # When true, skip starting servers when their port is already accepting connections
+    attr_accessor :dont_start_server_if_port_already_bound
+
     def initialize
       @sites = []
       @proxy_requests = !Rails.env.production?
       @serve_compiled_assets = Rails.env.production?
       @ping_server_timeout = 5
       @set_csrf_token_cookie = false
+      @dont_start_server_if_port_already_bound = Rails.env.test?
     end
 
     attr_reader :sites

--- a/lib/static-rails/error.rb
+++ b/lib/static-rails/error.rb
@@ -1,3 +1,4 @@
 module StaticRails
   class Error < StandardError; end
+  class ConnectionFailure < StandardError; end
 end

--- a/lib/static-rails/makes_connection.rb
+++ b/lib/static-rails/makes_connection.rb
@@ -1,0 +1,14 @@
+module StaticRails
+  class MakesConnection
+    def call(host:, port:, timeout:, raise_on_failure: true)
+      Socket.tcp(host, port, connect_timeout: timeout)
+      true
+    rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL => e
+      if raise_on_failure
+        raise ConnectionFailure.new(e.message)
+      else
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
**DOES NOT WORK**

Goal here was to skip server start up in the event that a server is already accepting requests at a given port, but fails to recognize that Rails will fork N times much faster than any server could start up, so you still end up with N server start attempts, which will behave wildly differently depending on the static site generator being used (Hugo in particular makes a real mess by searching for the same free ports one after another)

So I guess this means the only real option here is to find a way to subscribe to the fork event and only start servers initially if we're _not_ a forked startup?