### PR TITLE
Don't cache HTML/XML

### DIFF
--- a/example/cypress/integration/static-rails.js
+++ b/example/cypress/integration/static-rails.js
@@ -59,7 +59,7 @@ describe('rails-static stuff seems to work', () => {
     })
   })
 
-  it('[Production only] assign better cache-control', () => {
+  it('[Production only] assign better cache-control for images', () => {
     if (Cypress.env('RAILS_ENV') !== 'production') return
 
     cy.request('http://localhost:3009/docs/assets/an_image.png').should((response) => {
@@ -90,6 +90,18 @@ describe('rails-static stuff seems to work', () => {
         }
       }).should((response) => {
         expect(response.status).to.eq(304)
+      })
+    })
+  })
+
+  it('[Production only] cache-control no cache for HTML', () => {
+    if (Cypress.env('RAILS_ENV') !== 'production') return
+
+    cy.request('http://blog.localhost:3009/docs/index.html').should((response) => {
+      expect(response.headers).to.include({
+        'cache-control': 'no-cache, no-store',
+        // 'content-length': '4320',
+        'content-type': 'text/html'
       })
     })
   })

--- a/lib/static-rails/static_middleware.rb
+++ b/lib/static-rails/static_middleware.rb
@@ -53,6 +53,17 @@ module StaticRails
       return unless file
       file_handler.serve(req, *file).tap do |result|
         result[0] = status_override unless status_override.nil?
+        override_cache_control_if_we_probably_shouldnt_cache!(result[1], file)
+      end
+    end
+
+    PROBABLY_SHOULDNT_CACHE_MIME_TYPES = [
+      "text/html", "application/xml", "application/rss+xml"
+    ]
+    def override_cache_control_if_we_probably_shouldnt_cache!(headers, file)
+      mime_type = file[1]["Content-Type"]
+      if PROBABLY_SHOULDNT_CACHE_MIME_TYPES.include?(mime_type)
+        headers["cache-control"] = "no-cache, no-store"
       end
     end
   end

--- a/lib/static-rails/static_middleware.rb
+++ b/lib/static-rails/static_middleware.rb
@@ -53,14 +53,14 @@ module StaticRails
       return unless file
       file_handler.serve(req, *file).tap do |result|
         result[0] = status_override unless status_override.nil?
-        override_cache_control_if_we_probably_shouldnt_cache!(result[1], file)
+        override_cache_control_if_we_probably_shouldnt_cache!(file, result[1])
       end
     end
 
     PROBABLY_SHOULDNT_CACHE_MIME_TYPES = [
       "text/html", "application/xml", "application/rss+xml"
     ]
-    def override_cache_control_if_we_probably_shouldnt_cache!(headers, file)
+    def override_cache_control_if_we_probably_shouldnt_cache!(file, headers = {})
       mime_type = file[1]["Content-Type"]
       if PROBABLY_SHOULDNT_CACHE_MIME_TYPES.include?(mime_type)
         headers["cache-control"] = "no-cache, no-store"


### PR DESCRIPTION
For how this gem is intended to be used (serving up HTML & XML that references static assets that should be fingerprinted and cached basically indefinitely), it doesn't make sense that we're also setting a permanent cache header for HTML pages, which can dramatically slow down adoption of JS/CSS asset updates as a result.